### PR TITLE
ci: psqldefスキーマ自動適用

### DIFF
--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -4,16 +4,19 @@ on:
   push:
     branches:
       - main
+      - production
     paths:
       - "backend/database/**"
 
 concurrency:
-  group: deploy-schema
+  group: deploy-schema-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
-  deploy-schema:
+  deploy-staging:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: staging
     permissions:
       contents: read
     steps:
@@ -42,6 +45,21 @@ jobs:
           DB_NAME_STG: ${{ secrets.DB_NAME_STG }}
         run: |
           psqldef -h "$DB_HOST_STG" -U "$DB_USER_STG" -p 5432 "$DB_NAME_STG" < backend/database/postgres/schema.sql
+
+  deploy-production:
+    if: github.ref == 'refs/heads/production'
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install psqldef
+        run: |
+          curl -sL https://github.com/sqldef/sqldef/releases/latest/download/psqldef_linux_amd64.tar.gz | tar xz
+          sudo mv psqldef /usr/local/bin/
+          psqldef --version
 
       - name: Dry-run schema against production
         env:

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -1,0 +1,62 @@
+name: Deploy Database Schema
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/database/**"
+
+concurrency:
+  group: deploy-schema
+  cancel-in-progress: false
+
+jobs:
+  deploy-schema:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install psqldef
+        run: |
+          curl -sL https://github.com/sqldef/sqldef/releases/latest/download/psqldef_linux_amd64.tar.gz | tar xz
+          sudo mv psqldef /usr/local/bin/
+          psqldef --version
+
+      - name: Dry-run schema against staging
+        env:
+          PGPASSWORD: ${{ secrets.DB_PASSWORD_STG }}
+          DB_HOST_STG: ${{ secrets.DB_HOST_STG }}
+          DB_USER_STG: ${{ secrets.DB_USER_STG }}
+          DB_NAME_STG: ${{ secrets.DB_NAME_STG }}
+        run: |
+          psqldef -h "$DB_HOST_STG" -U "$DB_USER_STG" -p 5432 "$DB_NAME_STG" --dry-run < backend/database/postgres/schema.sql
+
+      - name: Apply schema to staging
+        env:
+          PGPASSWORD: ${{ secrets.DB_PASSWORD_STG }}
+          DB_HOST_STG: ${{ secrets.DB_HOST_STG }}
+          DB_USER_STG: ${{ secrets.DB_USER_STG }}
+          DB_NAME_STG: ${{ secrets.DB_NAME_STG }}
+        run: |
+          psqldef -h "$DB_HOST_STG" -U "$DB_USER_STG" -p 5432 "$DB_NAME_STG" < backend/database/postgres/schema.sql
+
+      - name: Dry-run schema against production
+        env:
+          PGPASSWORD: ${{ secrets.DB_PASSWORD_PROD }}
+          DB_HOST_PROD: ${{ secrets.DB_HOST_PROD }}
+          DB_USER_PROD: ${{ secrets.DB_USER_PROD }}
+          DB_NAME_PROD: ${{ secrets.DB_NAME_PROD }}
+        run: |
+          psqldef -h "$DB_HOST_PROD" -U "$DB_USER_PROD" -p 5432 "$DB_NAME_PROD" --dry-run < backend/database/postgres/schema.sql
+
+      - name: Apply schema to production
+        env:
+          PGPASSWORD: ${{ secrets.DB_PASSWORD_PROD }}
+          DB_HOST_PROD: ${{ secrets.DB_HOST_PROD }}
+          DB_USER_PROD: ${{ secrets.DB_USER_PROD }}
+          DB_NAME_PROD: ${{ secrets.DB_NAME_PROD }}
+        run: |
+          psqldef -h "$DB_HOST_PROD" -U "$DB_USER_PROD" -p 5432 "$DB_NAME_PROD" < backend/database/postgres/schema.sql


### PR DESCRIPTION
## Summary
- GitHub Actions workflow to auto-apply DB schema with psqldef on main merge
- Dry-run before apply for safety logging
- Sequential deploy: staging → production
- Credentials via GitHub secrets

## Test plan
- [ ] Verify workflow triggers on `backend/database/**` changes
- [ ] Confirm dry-run output is logged
- [ ] Test with staging database

close #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)