### PR TITLE
refactor: consolidate response helpers to response.go

### DIFF
--- a/backend/api/rest/auth_handler.go
+++ b/backend/api/rest/auth_handler.go
@@ -39,49 +39,44 @@ type userResponse struct {
 	Role string `json:"role"`
 }
 
-// errorResponse represents a JSON error response.
-type errorResponse struct {
-	Error string `json:"error"`
-}
-
 // HandleLogin handles POST /api/v1/auth/login requests.
 func (h *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 
 	var req loginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSONError(w, "invalid request body", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
 	req.Email = strings.TrimSpace(req.Email)
 
 	if req.Email == "" || req.Password == "" {
-		writeJSONError(w, "email and password are required", http.StatusBadRequest)
+		WriteError(w, http.StatusBadRequest, "email and password are required")
 		return
 	}
 
 	result, err := h.loginUseCase.Execute(r.Context(), req.Email, req.Password)
 	if err != nil {
 		if errors.Is(err, usecase.ErrInvalidCredentials) {
-			writeJSONError(w, "invalid email or password", http.StatusUnauthorized)
+			WriteError(w, http.StatusUnauthorized, "invalid email or password")
 			return
 		}
 		if errors.Is(err, usecase.ErrUserNotMentor) {
-			writeJSONError(w, "only mentors can log in", http.StatusForbidden)
+			WriteError(w, http.StatusForbidden, "only mentors can log in")
 			return
 		}
-		writeJSONError(w, "internal server error", http.StatusInternalServerError)
+		WriteError(w, http.StatusInternalServerError, "internal server error")
 		return
 	}
 
-	writeJSON(w, loginResponse{
+	WriteJSON(w, http.StatusOK, loginResponse{
 		Token: result.Token,
 		User:  toUserResponse(result.User),
-	}, http.StatusOK)
+	})
 }
 
 // toUserResponse converts an entity User to a userResponse.
@@ -91,20 +86,4 @@ func toUserResponse(user entities.User) userResponse {
 		Name: user.Name,
 		Role: string(user.Role),
 	}
-}
-
-// writeJSON writes a JSON response with the given status code.
-func writeJSON(w http.ResponseWriter, data interface{}, statusCode int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
-	}
-}
-
-// writeJSONError writes a JSON error response with the given status code.
-func writeJSONError(w http.ResponseWriter, message string, statusCode int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(errorResponse{Error: message})
 }

--- a/backend/api/rest/github_handler.go
+++ b/backend/api/rest/github_handler.go
@@ -41,43 +41,39 @@ type updateTokenRequest struct {
 	PersonalAccessToken string `json:"personal_access_token"`
 }
 
-type errorResponse struct {
-	Error string `json:"error"`
-}
-
 // RegisterRepository handles POST /api/v1/teams/:teamId/github-repos
 func (h *GitHubHandler) RegisterRepository(w http.ResponseWriter, r *http.Request) {
 	teamID := extractPathParam(r.URL.Path, "teams")
 	if teamID == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
 		return
 	}
 
 	var req registerRepoRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
 		return
 	}
 
 	if err := h.service.RegisterRepository(r.Context(), teamID, req.GitHubRepoURL, req.PersonalAccessToken); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, registerRepoResponse{Message: "repository registered successfully"})
+	WriteJSON(w, http.StatusCreated, registerRepoResponse{Message: "repository registered successfully"})
 }
 
 // ListRepositories handles GET /api/v1/teams/:teamId/github-repos
 func (h *GitHubHandler) ListRepositories(w http.ResponseWriter, r *http.Request) {
 	teamID := extractPathParam(r.URL.Path, "teams")
 	if teamID == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
 		return
 	}
 
 	repos, err := h.service.ListRepositories(r.Context(), teamID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: err.Error()})
+		WriteJSON(w, http.StatusInternalServerError, errorResponse{Error: err.Error()})
 		return
 	}
 
@@ -90,7 +86,7 @@ func (h *GitHubHandler) ListRepositories(w http.ResponseWriter, r *http.Request)
 		})
 	}
 
-	writeJSON(w, http.StatusOK, listReposResponse{Repos: items})
+	WriteJSON(w, http.StatusOK, listReposResponse{Repos: items})
 }
 
 // RemoveRepository handles DELETE /api/v1/teams/:teamId/github-repos/:repoId
@@ -99,20 +95,20 @@ func (h *GitHubHandler) RemoveRepository(w http.ResponseWriter, r *http.Request)
 	repoID := extractPathParam(r.URL.Path, "github-repos")
 
 	if teamID == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
 		return
 	}
 	if repoID == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "repo_id is required in path"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "repo_id is required in path"})
 		return
 	}
 
 	if err := h.service.RemoveRepository(r.Context(), teamID, repoID); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"message": "repository removed successfully"})
+	WriteJSON(w, http.StatusOK, map[string]string{"message": "repository removed successfully"})
 }
 
 // UpdateToken handles PUT /api/v1/teams/:teamId/github-repos/:repoId
@@ -121,26 +117,26 @@ func (h *GitHubHandler) UpdateToken(w http.ResponseWriter, r *http.Request) {
 	repoID := extractPathParam(r.URL.Path, "github-repos")
 
 	if teamID == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "team_id is required in path"})
 		return
 	}
 	if repoID == "" {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "repo_id is required in path"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "repo_id is required in path"})
 		return
 	}
 
 	var req updateTokenRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
 		return
 	}
 
 	if err := h.service.UpdateToken(r.Context(), teamID, repoID, req.PersonalAccessToken); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"message": "token updated successfully"})
+	WriteJSON(w, http.StatusOK, map[string]string{"message": "token updated successfully"})
 }
 
 // extractPathParam extracts the value after the given segment in a URL path.
@@ -153,10 +149,4 @@ func extractPathParam(urlPath string, segment string) string {
 		}
 	}
 	return ""
-}
-
-func writeJSON(w http.ResponseWriter, statusCode int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(v)
 }

--- a/backend/api/rest/internal_handler.go
+++ b/backend/api/rest/internal_handler.go
@@ -32,15 +32,15 @@ type createIssueResponse struct {
 func (h *InternalHandler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	var req createIssueRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
 		return
 	}
 
 	issueURL, err := h.service.CreateIssue(r.Context(), req.ChannelID, req.Title, req.Body)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		WriteJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, createIssueResponse{IssueURL: issueURL})
+	WriteJSON(w, http.StatusCreated, createIssueResponse{IssueURL: issueURL})
 }

--- a/backend/api/rest/response.go
+++ b/backend/api/rest/response.go
@@ -21,3 +21,8 @@ func WriteError(w http.ResponseWriter, status int, message string) {
 	resp := map[string]string{"error": message}
 	WriteJSON(w, status, resp)
 }
+
+// errorResponse represents a JSON error response.
+type errorResponse struct {
+	Error string `json:"error"`
+}


### PR DESCRIPTION
## Summary
- auth_handler.go の private writeJSON/writeJSONError を削除
- github_handler.go, internal_handler.go の private writeJSON を削除
- 全ハンドラーで response.go の public WriteJSON/WriteError を使用

close #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)