### PR TITLE
refactor: consolidate port interfaces into application/port package

### DIFF
--- a/backend/application/port/encryptor.go
+++ b/backend/application/port/encryptor.go
@@ -1,0 +1,7 @@
+package port
+
+// TokenEncryptor defines operations for encrypting and decrypting tokens.
+type TokenEncryptor interface {
+	Encrypt(plaintext string) (string, error)
+	Decrypt(ciphertext string) (string, error)
+}

--- a/backend/application/port/github_issue.go
+++ b/backend/application/port/github_issue.go
@@ -1,0 +1,8 @@
+package port
+
+import "context"
+
+// GitHubIssueCreator defines the operation for creating GitHub Issues via the GitHub API.
+type GitHubIssueCreator interface {
+	CreateIssue(ctx context.Context, owner, repo, token, title, body string) (issueURL string, err error)
+}

--- a/backend/application/port/github_repo.go
+++ b/backend/application/port/github_repo.go
@@ -1,4 +1,4 @@
-package application
+package port
 
 import (
 	"context"
@@ -14,15 +14,4 @@ type GitHubRepoRepository interface {
 	FindByChannelID(ctx context.Context, channelID string) (*entities.GitHubRepo, error)
 	Delete(ctx context.Context, repoID string) error
 	UpdateToken(ctx context.Context, repoID string, encryptedToken string) error
-}
-
-// TokenEncryptor defines operations for encrypting and decrypting tokens.
-type TokenEncryptor interface {
-	Encrypt(plaintext string) (string, error)
-	Decrypt(ciphertext string) (string, error)
-}
-
-// GitHubIssueCreator defines the operation for creating GitHub Issues via the GitHub API.
-type GitHubIssueCreator interface {
-	CreateIssue(ctx context.Context, owner, repo, token, title, body string) (issueURL string, err error)
 }

--- a/backend/application/service/github_service.go
+++ b/backend/application/service/github_service.go
@@ -6,24 +6,24 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Asheze1127/progress-checker/backend/application"
+	"github.com/Asheze1127/progress-checker/backend/application/port"
 	"github.com/Asheze1127/progress-checker/backend/entities"
 )
 
 // GitHubService handles GitHub repository management and Issue creation.
 type GitHubService struct {
-	repo       application.GitHubRepoRepository
-	encryptor  application.TokenEncryptor
-	ghClient   application.GitHubIssueCreator
+	repo       port.GitHubRepoRepository
+	encryptor  port.TokenEncryptor
+	ghClient   port.GitHubIssueCreator
 	idProvider func() string
 }
 
 // NewGitHubService creates a new GitHubService.
 // idProvider generates unique IDs for new GitHubRepo entities.
 func NewGitHubService(
-	repo application.GitHubRepoRepository,
-	encryptor application.TokenEncryptor,
-	ghClient application.GitHubIssueCreator,
+	repo port.GitHubRepoRepository,
+	encryptor port.TokenEncryptor,
+	ghClient port.GitHubIssueCreator,
 	idProvider func() string,
 ) *GitHubService {
 	return &GitHubService{

--- a/backend/infrastructure/postgres/github_repo_repository.go
+++ b/backend/infrastructure/postgres/github_repo_repository.go
@@ -5,16 +5,16 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/Asheze1127/progress-checker/backend/application"
+	"github.com/Asheze1127/progress-checker/backend/application/port"
 	db "github.com/Asheze1127/progress-checker/backend/database/postgres/generated"
 	"github.com/Asheze1127/progress-checker/backend/entities"
 	"github.com/google/uuid"
 )
 
 // Compile-time interface check.
-var _ application.GitHubRepoRepository = (*GitHubRepoRepository)(nil)
+var _ port.GitHubRepoRepository = (*GitHubRepoRepository)(nil)
 
-// GitHubRepoRepository implements application.GitHubRepoRepository using sqlc-generated queries.
+// GitHubRepoRepository implements port.GitHubRepoRepository using sqlc-generated queries.
 type GitHubRepoRepository struct {
 	queries *db.Queries
 }


### PR DESCRIPTION
## Summary
- application/port.go の3 interface を application/port/ 配下の個別ファイルに分割
- application/port.go を削除
- github_service.go, github_repo_repository.go のimportを更新

close #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)