### PR TITLE
refactor: replace log.Printf with structured slog logging

### DIFF
--- a/backend/api/rest/event_handler.go
+++ b/backend/api/rest/event_handler.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 
@@ -66,7 +66,7 @@ func (h *EventHandler) handleURLVerification(w http.ResponseWriter, event slackp
 	w.Header().Set("Content-Type", "application/json")
 	resp := slackpkg.URLVerificationResponse{Challenge: event.Challenge}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		log.Printf("failed to encode url_verification response: %v", err)
+		slog.Error("failed to encode url_verification response", slog.String("error", err.Error()))
 	}
 }
 
@@ -93,7 +93,7 @@ func (h *EventHandler) handleReactionAdded(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := h.issueTrigger.Execute(r.Context(), input); err != nil {
-		log.Printf("failed to trigger issue creation from reaction: %v", err)
+		slog.Error("failed to trigger issue creation from reaction", slog.String("error", err.Error()))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -115,7 +115,7 @@ func (h *EventHandler) handleMessageAction(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := h.issueTrigger.Execute(r.Context(), input); err != nil {
-		log.Printf("failed to trigger issue creation from message action: %v", err)
+		slog.Error("failed to trigger issue creation from message action", slog.String("error", err.Error()))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/backend/api/rest/interaction_handler.go
+++ b/backend/api/rest/interaction_handler.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/Asheze1127/progress-checker/backend/application/usecase"
@@ -59,7 +59,7 @@ func (h *InteractionHandler) HandleInteraction(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := r.ParseForm(); err != nil {
-		log.Printf("error parsing form: %v", err)
+		slog.Error("error parsing form", slog.String("error", err.Error()))
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
@@ -72,7 +72,7 @@ func (h *InteractionHandler) HandleInteraction(w http.ResponseWriter, r *http.Re
 
 	var payload slackInteractionPayload
 	if err := json.Unmarshal([]byte(rawPayload), &payload); err != nil {
-		log.Printf("error unmarshaling interaction payload: %v", err)
+		slog.Error("error unmarshaling interaction payload", slog.String("error", err.Error()))
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
 	}
@@ -88,7 +88,7 @@ func (h *InteractionHandler) HandleInteraction(w http.ResponseWriter, r *http.Re
 	questionID := entities.QuestionID(action.Value)
 
 	if questionID == "" {
-		log.Printf("interaction from user %s has empty question ID", payload.User.ID)
+		slog.Warn("interaction has empty question ID", slog.String("user_id", payload.User.ID))
 		http.Error(w, "missing question ID", http.StatusBadRequest)
 		return
 	}
@@ -104,13 +104,13 @@ func (h *InteractionHandler) HandleInteraction(w http.ResponseWriter, r *http.Re
 	case slackpkg.ActionIDQuestionEscalate:
 		err = h.escalateQuestion.Execute(ctx, questionID)
 	default:
-		log.Printf("unknown action_id %q from user %s", action.ActionID, payload.User.ID)
+		slog.Warn("unknown action_id", slog.String("action_id", action.ActionID), slog.String("user_id", payload.User.ID))
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
 	if err != nil {
-		log.Printf("error handling action %q for question %q: %v", action.ActionID, questionID, err)
+		slog.Error("error handling action", slog.String("action_id", action.ActionID), slog.String("question_id", string(questionID)), slog.String("error", err.Error()))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/backend/api/rest/progress_handler.go
+++ b/backend/api/rest/progress_handler.go
@@ -1,7 +1,7 @@
 package rest
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -59,7 +59,7 @@ func (h *ProgressHandler) HandleListProgress(w http.ResponseWriter, r *http.Requ
 
 	results, err := h.listProgressUC.Execute(r.Context(), teamID)
 	if err != nil {
-		log.Printf("failed to list latest progress: %v", err)
+		slog.Error("failed to list latest progress", slog.String("error", err.Error()))
 		WriteError(w, http.StatusInternalServerError, "internal server error")
 		return
 	}

--- a/backend/api/rest/question_handler.go
+++ b/backend/api/rest/question_handler.go
@@ -1,7 +1,7 @@
 package rest
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/Asheze1127/progress-checker/backend/application/usecase"
@@ -78,7 +78,7 @@ func (h *QuestionHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.handleNewQuestionUC.Execute(r.Context(), input); err != nil {
-		log.Printf("ERROR: failed to handle new question: %v", err)
+		slog.Error("failed to handle new question", slog.String("error", err.Error()))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/backend/api/rest/response.go
+++ b/backend/api/rest/response.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 )
 
@@ -12,7 +12,7 @@ func WriteJSON(w http.ResponseWriter, status int, data any) {
 	w.WriteHeader(status)
 
 	if err := json.NewEncoder(w).Encode(data); err != nil {
-		log.Printf("failed to encode JSON response: %v", err)
+		slog.Error("failed to encode JSON response", slog.String("error", err.Error()))
 	}
 }
 

--- a/backend/api/rest/webhook_handler.go
+++ b/backend/api/rest/webhook_handler.go
@@ -1,7 +1,7 @@
 package rest
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/Asheze1127/progress-checker/backend/application/usecase"
@@ -65,7 +65,7 @@ func (h *WebhookHandler) handleProgress(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if err := h.progressUseCase.Execute(r.Context(), input); err != nil {
-		log.Printf("ERROR: failed to handle progress command: %v", err)
+		slog.Error("failed to handle progress command", slog.String("error", err.Error()))
 		http.Error(w, "failed to process progress command", http.StatusInternalServerError)
 		return
 	}

--- a/backend/cmd/serve/command.go
+++ b/backend/cmd/serve/command.go
@@ -2,14 +2,17 @@ package serve
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/Asheze1127/progress-checker/backend/util"
 )
 
 // Run starts the HTTP server with all dependencies wired.
 func Run() error {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+
 	cfg, err := util.LoadConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
@@ -21,7 +24,7 @@ func Run() error {
 	}
 
 	addr := fmt.Sprintf(":%s", cfg.Port)
-	log.Printf("Starting server on %s", addr)
+	slog.Info("starting server", slog.String("addr", addr))
 
 	return http.ListenAndServe(addr, router)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,13 +1,15 @@
 package main
 
 import (
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/Asheze1127/progress-checker/backend/cmd/serve"
 )
 
 func main() {
 	if err := serve.Run(); err != nil {
-		log.Fatalf("server error: %v", err)
+		slog.Error("server error", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary
- 全ハンドラー・main.go の log.Printf を log/slog に移行
- 構造化フィールド（error, user_id, action_id等）を付与
- cmd/serve で JSON slog handler を設定

close #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)