### PR TITLE
fix: add nil guards for unimplemented dependencies

### DIFF
--- a/backend/application/service/question_sender.go
+++ b/backend/application/service/question_sender.go
@@ -33,6 +33,10 @@ func NewQuestionSender(queue port.MessageQueue) *QuestionSender {
 
 // SendNewQuestion sends a new question message to the SQS queue.
 func (s *QuestionSender) SendNewQuestion(ctx context.Context, msg QuestionNewMessage) error {
+	if s.queue == nil {
+		return fmt.Errorf("message queue not configured")
+	}
+
 	msg.Type = "question_new"
 
 	msgBytes, err := json.Marshal(msg)

--- a/backend/application/usecase/escalate_question.go
+++ b/backend/application/usecase/escalate_question.go
@@ -43,6 +43,10 @@ func (u *EscalateQuestionUsecase) Execute(ctx context.Context, questionID entiti
 		return fmt.Errorf("updating question %q to assigned_mentor: %w", questionID, err)
 	}
 
+	if u.slackNotifier == nil {
+		return fmt.Errorf("slack notifier not configured")
+	}
+
 	if err := u.slackNotifier.PostToMentorChannel(ctx, question); err != nil {
 		return fmt.Errorf("posting question %q to mentor channel: %w", questionID, err)
 	}

--- a/backend/application/usecase/trigger_issue_creation.go
+++ b/backend/application/usecase/trigger_issue_creation.go
@@ -76,6 +76,10 @@ func (uc *TriggerIssueCreationUseCase) Execute(ctx context.Context, input Trigge
 		return fmt.Errorf("invalid input: %w", err)
 	}
 
+	if uc.threadFetcher == nil || uc.queue == nil {
+		return fmt.Errorf("issue creation dependencies not configured")
+	}
+
 	messages, err := uc.threadFetcher.FetchThreadMessages(ctx, input.ChannelID, input.ThreadTS)
 	if err != nil {
 		return fmt.Errorf("failed to fetch thread messages: %w", err)


### PR DESCRIPTION
## Summary
コードレビューで指摘されたnil pointer panic問題を修正。

DI配線で未実装のインターフェース（SlackNotifier, SlackThreadFetcher, MessageQueue）に
nilが渡されている箇所で、パニックせずエラーを返すようnilガードを追加。

- `escalate_question.go`: slackNotifier nil check
- `trigger_issue_creation.go`: threadFetcher/queue nil check
- `question_sender.go`: queue nil check

🤖 Generated with [Claude Code](https://claude.com/claude-code)