### PR TITLE
fix: align question_resolve action_id with Go backend constant

### DIFF
--- a/lambda/worker/question.test.ts
+++ b/lambda/worker/question.test.ts
@@ -134,7 +134,7 @@ describe("buildResponseBlocks", () => {
     expect(actionsBlock.elements).toHaveLength(3);
 
     const actionIds = actionsBlock.elements.map((e) => e.action_id);
-    expect(actionIds).toContain("question_resolve");
+    expect(actionIds).toContain("question_resolved");
     expect(actionIds).toContain("question_continue");
     expect(actionIds).toContain("question_escalate");
 

--- a/lambda/worker/question.ts
+++ b/lambda/worker/question.ts
@@ -63,7 +63,7 @@ export function buildResponseBlocks(
     {
       type: "button",
       text: { type: "plain_text", text: "解決済み" },
-      action_id: "question_resolve",
+      action_id: "question_resolved",
       style: "primary",
       value: questionId,
     },


### PR DESCRIPTION
## Summary
- Fixes #137
- Changed `action_id` from `"question_resolve"` to `"question_resolved"` in `lambda/worker/question.ts` to match the Go backend constant `ActionIDQuestionResolved` defined in `backend/pkg/slack/blocks.go`
- Updated the corresponding test assertion in `lambda/worker/question.test.ts`

## Root Cause
The Lambda worker sent `action_id: "question_resolve"` but the Go interaction handler at `backend/api/rest/interaction_handler.go:100` matches on `"question_resolved"` (with a trailing `d`). This mismatch caused the resolve button click to be silently ignored.

## Test plan
- [x] `npx vitest run worker/question.test.ts` passes (8/8 tests)
- [x] No remaining references to the old incorrect `question_resolve` value in `.ts`, `.js`, or `.go` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)