### PR TITLE
fix: collect errors per-record in question-followup handler (#139)

### DIFF
--- a/lambda/worker/question-followup.test.ts
+++ b/lambda/worker/question-followup.test.ts
@@ -281,7 +281,7 @@ describe("handler", () => {
 
     const event = createSqsEvent([createValidMessage()]);
 
-    await expect(handler(event, mockContext, mockCallback)).rejects.toThrow("Model unavailable");
+    await expect(handler(event, mockContext, mockCallback)).rejects.toThrow("Failed to process 1 record(s)");
   });
 
   it("should handle events with no records", async () => {

--- a/lambda/worker/question-followup.ts
+++ b/lambda/worker/question-followup.ts
@@ -248,11 +248,12 @@ export const handler: SQSHandler = async (event: SQSEvent): Promise<void> => {
     }),
   );
 
+  const errors: Array<{ messageId: string; error: unknown }> = [];
+
   for (const record of event.Records) {
     try {
       await processRecord(record);
     } catch (error) {
-      // Handle errors per-record to prevent one failure from blocking others
       console.error(
         JSON.stringify({
           action: "record_processing_error",
@@ -260,7 +261,11 @@ export const handler: SQSHandler = async (event: SQSEvent): Promise<void> => {
           error: error instanceof Error ? error.message : String(error),
         }),
       );
-      throw error;
+      errors.push({ messageId: record.messageId, error });
     }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Failed to process ${errors.length} record(s)`);
   }
 };


### PR DESCRIPTION
## Summary
- Fixed bug in `lambda/worker/question-followup.ts` where the SQS handler threw on the first record error, preventing subsequent records from being processed
- Changed error handling to collect all errors in an array and throw a summary error after processing all records, matching the pattern used in `lambda/worker/issue.ts`
- Updated test expectation to match the new summary error message

Closes #139

## Test plan
- [x] Verified question-followup tests pass with the new error handling
- [x] Confirmed pre-existing issue.test.ts failures are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)