### PR TITLE
refactor: extract shared postSlackMessage module (#140)

### DIFF
--- a/lambda/worker/issue.test.ts
+++ b/lambda/worker/issue.test.ts
@@ -162,6 +162,8 @@ describe("handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    process.env.SLACK_BOT_TOKEN = "xoxb-test-token";
+
     (generateText as Mock).mockResolvedValue({ text: MOCK_LLM_RESPONSE });
 
     mockFetch = vi.fn();

--- a/lambda/worker/issue.ts
+++ b/lambda/worker/issue.ts
@@ -1,6 +1,7 @@
 import { generateText } from "ai";
 import { bedrock } from "@ai-sdk/amazon-bedrock";
 import type { SQSEvent, SQSHandler } from "aws-lambda";
+import { postSlackMessage } from "./shared/slack";
 
 interface ThreadMessage {
   user: string;
@@ -28,7 +29,6 @@ interface IssueApiResponse {
 
 const ISSUE_API_HOSTNAME = process.env.ISSUE_API_HOSTNAME ?? "";
 const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN ?? "";
-const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN ?? "";
 const LLM_MODEL_ID = "anthropic.claude-3-5-sonnet-20241022-v2:0";
 
 const SYSTEM_PROMPT = [
@@ -135,30 +135,6 @@ async function createGitHubIssue(channelId: string, title: string, body: string)
   return result as IssueApiResponse;
 }
 
-async function postSlackMessage(channelId: string, threadTs: string, text: string): Promise<void> {
-  const response = await fetch("https://slack.com/api/chat.postMessage", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${SLACK_BOT_TOKEN}`,
-    },
-    body: JSON.stringify({
-      channel: channelId,
-      thread_ts: threadTs,
-      text,
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Slack API returned ${String(response.status)}`);
-  }
-
-  const result = (await response.json()) as { ok: boolean; error?: string };
-  if (!result.ok) {
-    throw new Error(`Slack API error: ${result.error ?? "unknown"}`);
-  }
-}
-
 async function processIssueCreation(message: IssueMessage): Promise<void> {
   console.log(
     JSON.stringify({
@@ -180,7 +156,7 @@ async function processIssueCreation(message: IssueMessage): Promise<void> {
 
   console.log(JSON.stringify({ event: "issue_created", issueUrl }));
 
-  await postSlackMessage(message.channel_id, message.thread_ts, `GitHub Issue created: ${issueUrl}`);
+  await postSlackMessage({ channelId: message.channel_id, threadTs: message.thread_ts, text: `GitHub Issue created: ${issueUrl}` });
 
   console.log(JSON.stringify({ event: "issue_creation_completed", issueUrl }));
 }

--- a/lambda/worker/question-followup.test.ts
+++ b/lambda/worker/question-followup.test.ts
@@ -188,6 +188,7 @@ describe("processFollowupQuestion", () => {
     process.env.SLACK_BOT_TOKEN = "xoxb-test-token";
 
     mockFetch.mockResolvedValue({
+      ok: true,
       json: () => Promise.resolve({ ok: true }),
     });
   });
@@ -239,6 +240,7 @@ describe("processFollowupQuestion", () => {
   it("should throw when Slack API returns an error", async () => {
     mockGenerateText.mockResolvedValue({ text: "response" });
     mockFetch.mockResolvedValue({
+      ok: true,
       json: () => Promise.resolve({ ok: false, error: "channel_not_found" }),
     });
 
@@ -263,6 +265,7 @@ describe("handler", () => {
     });
 
     mockFetch.mockResolvedValue({
+      ok: true,
       json: () => Promise.resolve({ ok: true }),
     });
   });

--- a/lambda/worker/question-followup.ts
+++ b/lambda/worker/question-followup.ts
@@ -1,6 +1,7 @@
 import { generateText } from "ai";
 import { bedrock } from "@ai-sdk/amazon-bedrock";
 import type { SQSEvent, SQSHandler, SQSRecord } from "aws-lambda";
+import { postSlackMessage } from "./shared/slack";
 
 // Bedrock model identifier for Claude 3.5 Sonnet v2
 const BEDROCK_MODEL_ID = "anthropic.claude-3-5-sonnet-20241022-v2:0";
@@ -48,11 +49,6 @@ export interface FollowupMessage {
   slack_channel_id: string;
   slack_thread_ts: string;
   thread_messages: ThreadMessage[];
-}
-
-interface SlackPostResult {
-  ok: boolean;
-  error?: string;
 }
 
 // AI-generated content disclaimer appended to every response
@@ -110,36 +106,6 @@ export function detectResponseIntent(responseText: string): "followup_needed" | 
 }
 
 /**
- * Post a message to a Slack thread.
- */
-async function postSlackMessage(channelId: string, threadTs: string, text: string): Promise<SlackPostResult> {
-  const slackToken = process.env.SLACK_BOT_TOKEN;
-  if (!slackToken) {
-    throw new Error("SLACK_BOT_TOKEN environment variable is not set");
-  }
-
-  const response = await fetch("https://slack.com/api/chat.postMessage", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      Authorization: `Bearer ${slackToken}`,
-    },
-    body: JSON.stringify({
-      channel: channelId,
-      thread_ts: threadTs,
-      text,
-    }),
-  });
-
-  const result = (await response.json()) as SlackPostResult;
-  if (!result.ok) {
-    throw new Error(`Slack API error: ${result.error ?? "unknown"}`);
-  }
-
-  return result;
-}
-
-/**
  * Update the question session status in the session store.
  */
 async function updateQuestionSessionStatus(questionId: string, status: string): Promise<void> {
@@ -171,7 +137,7 @@ export async function processFollowupQuestion(message: FollowupMessage): Promise
 
   const responseWithDisclaimer = aiResponse + AI_DISCLAIMER;
 
-  await postSlackMessage(slack_channel_id, slack_thread_ts, responseWithDisclaimer);
+  await postSlackMessage({ channelId: slack_channel_id, threadTs: slack_thread_ts, text: responseWithDisclaimer });
 
   const intent = detectResponseIntent(aiResponse);
 

--- a/lambda/worker/question.ts
+++ b/lambda/worker/question.ts
@@ -1,8 +1,8 @@
 import { bedrock } from "@ai-sdk/amazon-bedrock";
 import type { KnownBlock } from "@slack/web-api";
-import { WebClient } from "@slack/web-api";
 import { generateText } from "ai";
 import type { SQSEvent, SQSHandler } from "aws-lambda";
+import { postSlackMessage } from "./shared/slack";
 
 // --- Types ---
 
@@ -38,14 +38,6 @@ Provide clear, actionable answers. When the question is ambiguous, ask a focused
 Always respond in the same language as the question.`;
 
 // --- Slack helpers ---
-
-function createSlackClient(): WebClient {
-  const token = process.env.SLACK_BOT_TOKEN;
-  if (!token) {
-    throw new Error("SLACK_BOT_TOKEN environment variable is not set");
-  }
-  return new WebClient(token);
-}
 
 interface ActionButton {
   type: "button";
@@ -160,13 +152,7 @@ function createProductionDependencies(): Dependencies {
       text: string,
       blocks: KnownBlock[],
     ): Promise<void> => {
-      const slackClient = createSlackClient();
-      await slackClient.chat.postMessage({
-        channel: channelId,
-        thread_ts: threadTs,
-        text,
-        blocks,
-      });
+      await postSlackMessage({ channelId, threadTs, text, blocks });
     },
   };
 }

--- a/lambda/worker/shared/slack.ts
+++ b/lambda/worker/shared/slack.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared Slack messaging module for Lambda workers.
+ *
+ * Uses raw `fetch` to avoid pulling in the @slack/web-api SDK at runtime.
+ */
+
+export interface SlackPostResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface SlackMessageOptions {
+  channelId: string;
+  threadTs: string;
+  text: string;
+  blocks?: unknown[];
+}
+
+/**
+ * Post a message to a Slack channel/thread using the chat.postMessage API.
+ *
+ * Validates `SLACK_BOT_TOKEN` from environment, sends the request via fetch,
+ * and checks both HTTP status and the Slack API `ok` field.
+ */
+export async function postSlackMessage(options: SlackMessageOptions): Promise<SlackPostResult> {
+  const slackToken = process.env.SLACK_BOT_TOKEN;
+  if (!slackToken) {
+    throw new Error("SLACK_BOT_TOKEN environment variable is not set");
+  }
+
+  const payload: Record<string, unknown> = {
+    channel: options.channelId,
+    thread_ts: options.threadTs,
+    text: options.text,
+  };
+
+  if (options.blocks !== undefined) {
+    payload.blocks = options.blocks;
+  }
+
+  const response = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      Authorization: `Bearer ${slackToken}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Slack API returned HTTP ${String(response.status)}`);
+  }
+
+  const result = (await response.json()) as SlackPostResult;
+  if (!result.ok) {
+    throw new Error(`Slack API error: ${result.error ?? "unknown"}`);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Created `lambda/worker/shared/slack.ts` with a common `postSlackMessage` function using raw `fetch` (no SDK dependency)
- Updated `question.ts`, `question-followup.ts`, and `issue.ts` to use the shared module instead of their own duplicate implementations
- Removed `@slack/web-api` SDK usage from `question.ts` (now uses raw fetch like the others)
- Updated test mocks to match the shared module's HTTP response validation

Closes #140

## Test plan
- [x] TypeScript compilation passes with no errors
- [x] All previously passing tests continue to pass (47/49; 2 pre-existing failures in issue.test.ts unrelated to this change)
- [x] Verified shared module validates SLACK_BOT_TOKEN, checks HTTP status, and checks Slack API `ok` field

Generated with [Claude Code](https://claude.com/claude-code)
