### PR TITLE
refactor(slack): replace custom event/block types with slack-go library types

### DIFF
--- a/backend/api/rest/event_handler.go
+++ b/backend/api/rest/event_handler.go
@@ -3,11 +3,13 @@ package rest
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 
 	"github.com/Asheze1127/progress-checker/backend/application/usecase"
 	slackpkg "github.com/Asheze1127/progress-checker/backend/pkg/slack"
+	"github.com/slack-go/slack/slackevents"
 )
 
 // IssueTrigger defines the interface for triggering issue creation.
@@ -36,51 +38,82 @@ func (h *EventHandler) HandleSlackEvents(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var event slackpkg.SlackEvent
-	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	// Check raw type field first for message_action, which is not an Events API
+	// event and cannot be parsed by slackevents.ParseEvent.
+	var typeCheck struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(body, &typeCheck); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if typeCheck.Type == slackpkg.EventTypeMessageAction {
+		h.handleMessageAction(w, r, body)
+		return
+	}
+
+	event, err := slackevents.ParseEvent(json.RawMessage(body), slackevents.OptionNoVerifyToken())
+	if err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 
 	switch event.Type {
-	case slackpkg.EventTypeURLVerification:
-		h.handleURLVerification(w, event)
-	case slackpkg.EventTypeEventCallback:
+	case slackevents.URLVerification:
+		h.handleURLVerification(w, body)
+	case slackevents.CallbackEvent:
 		h.handleEventCallback(w, r, event)
-	case slackpkg.EventTypeMessageAction:
-		h.handleMessageAction(w, r, event)
 	default:
 		w.WriteHeader(http.StatusOK)
 	}
 }
 
-func (h *EventHandler) handleURLVerification(w http.ResponseWriter, event slackpkg.SlackEvent) {
+func (h *EventHandler) handleURLVerification(w http.ResponseWriter, body []byte) {
+	var challenge slackevents.ChallengeResponse
+	if err := json.Unmarshal(body, &challenge); err != nil {
+		slog.Error("failed to parse url_verification challenge", slog.String("error", err.Error()))
+		http.Error(w, "invalid challenge", http.StatusBadRequest)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	resp := slackpkg.URLVerificationResponse{Challenge: event.Challenge}
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
+	if err := json.NewEncoder(w).Encode(challenge); err != nil {
 		slog.Error("failed to encode url_verification response", slog.String("error", err.Error()))
 	}
 }
 
-func (h *EventHandler) handleEventCallback(w http.ResponseWriter, r *http.Request, event slackpkg.SlackEvent) {
-	switch event.Event.Type {
-	case slackpkg.EventTypeReactionAdded:
-		h.handleReactionAdded(w, r, event)
+func (h *EventHandler) handleEventCallback(w http.ResponseWriter, r *http.Request, event slackevents.EventsAPIEvent) {
+	innerEvent := event.InnerEvent
+	switch innerEvent.Type {
+	case string(slackevents.ReactionAdded):
+		h.handleReactionAdded(w, r, innerEvent)
 	default:
 		w.WriteHeader(http.StatusOK)
 	}
 }
 
-func (h *EventHandler) handleReactionAdded(w http.ResponseWriter, r *http.Request, event slackpkg.SlackEvent) {
-	if event.Event.Reaction != h.triggerEmoji {
+func (h *EventHandler) handleReactionAdded(w http.ResponseWriter, r *http.Request, innerEvent slackevents.EventsAPIInnerEvent) {
+	ev, ok := innerEvent.Data.(*slackevents.ReactionAddedEvent)
+	if !ok {
+		http.Error(w, "unexpected event data", http.StatusBadRequest)
+		return
+	}
+
+	if ev.Reaction != h.triggerEmoji {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
 	input := usecase.TriggerIssueCreationInput{
-		ChannelID:     event.Event.Item.Channel,
-		ThreadTS:      event.Event.Item.TS,
-		TriggerUserID: event.Event.User,
+		ChannelID:     ev.Item.Channel,
+		ThreadTS:      ev.Item.Timestamp,
+		TriggerUserID: ev.User,
 		TriggerType:   "reaction",
 	}
 
@@ -93,16 +126,22 @@ func (h *EventHandler) handleReactionAdded(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *EventHandler) handleMessageAction(w http.ResponseWriter, r *http.Request, event slackpkg.SlackEvent) {
-	threadTS := event.Message.ThreadTS
+func (h *EventHandler) handleMessageAction(w http.ResponseWriter, r *http.Request, body []byte) {
+	var payload slackpkg.MessageActionPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid message action payload", http.StatusBadRequest)
+		return
+	}
+
+	threadTS := payload.Message.ThreadTS
 	if threadTS == "" {
-		threadTS = event.Message.TS
+		threadTS = payload.Message.TS
 	}
 
 	input := usecase.TriggerIssueCreationInput{
-		ChannelID:     event.Channel.ID,
+		ChannelID:     payload.Channel.ID,
 		ThreadTS:      threadTS,
-		TriggerUserID: event.User.ID,
+		TriggerUserID: payload.User.ID,
 		TriggerType:   "message_action",
 	}
 

--- a/backend/api/rest/interaction_handler.go
+++ b/backend/api/rest/interaction_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Asheze1127/progress-checker/backend/application/usecase"
 	"github.com/Asheze1127/progress-checker/backend/entities"
 	slackpkg "github.com/Asheze1127/progress-checker/backend/pkg/slack"
+	"github.com/slack-go/slack"
 )
 
 // InteractionHandler handles Slack interactive component callbacks.
@@ -28,25 +29,6 @@ func NewInteractionHandler(
 		continueQuestion: cont,
 		escalateQuestion: escalate,
 	}
-}
-
-// slackInteractionPayload represents the top-level Slack interaction callback.
-type slackInteractionPayload struct {
-	Type    string            `json:"type"`
-	Actions []slackAction     `json:"actions"`
-	User    slackUser         `json:"user"`
-}
-
-// slackAction represents a single action within a Slack interaction payload.
-type slackAction struct {
-	ActionID string `json:"action_id"`
-	Value    string `json:"value"`
-}
-
-// slackUser represents the user who triggered the action.
-type slackUser struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
 }
 
 // HandleInteraction is the HTTP handler for POST /webhook/slack/interactions.
@@ -70,25 +52,25 @@ func (h *InteractionHandler) HandleInteraction(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	var payload slackInteractionPayload
-	if err := json.Unmarshal([]byte(rawPayload), &payload); err != nil {
+	var callback slack.InteractionCallback
+	if err := json.Unmarshal([]byte(rawPayload), &callback); err != nil {
 		slog.Error("error unmarshaling interaction payload", slog.String("error", err.Error()))
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
 	}
 
-	if len(payload.Actions) == 0 {
+	if len(callback.ActionCallback.BlockActions) == 0 {
 		// Acknowledge with 200 even when there are no actions to process.
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
 	// Process only the first action (Slack sends one action per interaction).
-	action := payload.Actions[0]
+	action := callback.ActionCallback.BlockActions[0]
 	questionID := entities.QuestionID(action.Value)
 
 	if questionID == "" {
-		slog.Warn("interaction has empty question ID", slog.String("user_id", payload.User.ID))
+		slog.Warn("interaction has empty question ID", slog.String("user_id", callback.User.ID))
 		http.Error(w, "missing question ID", http.StatusBadRequest)
 		return
 	}
@@ -104,7 +86,7 @@ func (h *InteractionHandler) HandleInteraction(w http.ResponseWriter, r *http.Re
 	case slackpkg.ActionIDQuestionEscalate:
 		err = h.escalateQuestion.Execute(ctx, questionID)
 	default:
-		slog.Warn("unknown action_id", slog.String("action_id", action.ActionID), slog.String("user_id", payload.User.ID))
+		slog.Warn("unknown action_id", slog.String("action_id", action.ActionID), slog.String("user_id", callback.User.ID))
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/backend/pkg/slack/blocks.go
+++ b/backend/pkg/slack/blocks.go
@@ -1,6 +1,6 @@
 package slack
 
-import "encoding/json"
+import "github.com/slack-go/slack"
 
 // Action IDs for interactive buttons shown after AI responses.
 const (
@@ -9,76 +9,31 @@ const (
 	ActionIDQuestionEscalate = "question_escalate"
 )
 
-// Button styles defined by Slack Block Kit.
-const (
-	ButtonStylePrimary = "primary"
-	ButtonStyleDanger  = "danger"
-)
-
-// Block represents a single Slack Block Kit block.
-type Block struct {
-	Type     string    `json:"type"`
-	Text     *TextObj  `json:"text,omitempty"`
-	Elements []Element `json:"elements,omitempty"`
-}
-
-// TextObj represents a Slack Block Kit text object.
-type TextObj struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
-}
-
-// Element represents a Slack Block Kit element such as a button.
-type Element struct {
-	Type    string  `json:"type"`
-	Text    TextObj `json:"text"`
-	ActionID string `json:"action_id"`
-	Style   string  `json:"style,omitempty"`
-	Value   string  `json:"value,omitempty"`
-}
-
 // BuildQuestionResponseBlocks returns Slack Block Kit blocks containing the AI
 // response text and three action buttons: resolve, continue, and escalate.
 // The questionID is embedded in each button's value so callbacks can identify
 // the target question.
-func BuildQuestionResponseBlocks(aiResponse string, questionID string) []Block {
-	return []Block{
-		{
-			Type: "section",
-			Text: &TextObj{
-				Type: "mrkdwn",
-				Text: aiResponse,
-			},
-		},
-		{
-			Type: "actions",
-			Elements: []Element{
-				{
-					Type:     "button",
-					Text:     TextObj{Type: "plain_text", Text: "\u2705 \u89e3\u6c7a\u3057\u305f"},
-					ActionID: ActionIDQuestionResolved,
-					Style:    ButtonStylePrimary,
-					Value:    questionID,
-				},
-				{
-					Type:     "button",
-					Text:     TextObj{Type: "plain_text", Text: "\U0001F4AC \u7d9a\u3051\u3066\u8cea\u554f"},
-					ActionID: ActionIDQuestionContinue,
-					Value:    questionID,
-				},
-				{
-					Type:     "button",
-					Text:     TextObj{Type: "plain_text", Text: "\U0001F64B \u30e1\u30f3\u30bf\u30fc\u306b\u76f8\u8ac7"},
-					ActionID: ActionIDQuestionEscalate,
-					Style:    ButtonStyleDanger,
-					Value:    questionID,
-				},
-			},
-		},
-	}
-}
+func BuildQuestionResponseBlocks(aiResponse string, questionID string) []slack.Block {
+	textBlock := slack.NewSectionBlock(
+		slack.NewTextBlockObject("mrkdwn", aiResponse, false, false),
+		nil, nil,
+	)
 
-// MarshalBlocks serializes blocks to JSON bytes.
-func MarshalBlocks(blocks []Block) ([]byte, error) {
-	return json.Marshal(blocks)
+	resolveBtn := slack.NewButtonBlockElement(ActionIDQuestionResolved, questionID,
+		slack.NewTextBlockObject("plain_text", "✅ 解決した", false, false),
+	)
+	resolveBtn.Style = slack.StylePrimary
+
+	continueBtn := slack.NewButtonBlockElement(ActionIDQuestionContinue, questionID,
+		slack.NewTextBlockObject("plain_text", "💬 続けて質問", false, false),
+	)
+
+	escalateBtn := slack.NewButtonBlockElement(ActionIDQuestionEscalate, questionID,
+		slack.NewTextBlockObject("plain_text", "🙋 メンターに相談", false, false),
+	)
+	escalateBtn.Style = slack.StyleDanger
+
+	actionBlock := slack.NewActionBlock("", resolveBtn, continueBtn, escalateBtn)
+
+	return []slack.Block{textBlock, actionBlock}
 }

--- a/backend/pkg/slack/blocks_test.go
+++ b/backend/pkg/slack/blocks_test.go
@@ -3,6 +3,8 @@ package slack
 import (
 	"encoding/json"
 	"testing"
+
+	goslack "github.com/slack-go/slack"
 )
 
 func TestBuildQuestionResponseBlocks(t *testing.T) {
@@ -16,8 +18,11 @@ func TestBuildQuestionResponseBlocks(t *testing.T) {
 	}
 
 	// Verify the section block contains the AI response.
-	section := blocks[0]
-	if section.Type != "section" {
+	section, ok := blocks[0].(*goslack.SectionBlock)
+	if !ok {
+		t.Fatalf("expected first block to be *SectionBlock, got %T", blocks[0])
+	}
+	if section.Type != goslack.MBTSection {
 		t.Errorf("expected first block type 'section', got %q", section.Type)
 	}
 	if section.Text == nil {
@@ -31,29 +36,33 @@ func TestBuildQuestionResponseBlocks(t *testing.T) {
 	}
 
 	// Verify the actions block has three buttons.
-	actions := blocks[1]
-	if actions.Type != "actions" {
+	actions, ok := blocks[1].(*goslack.ActionBlock)
+	if !ok {
+		t.Fatalf("expected second block to be *ActionBlock, got %T", blocks[1])
+	}
+	if actions.Type != goslack.MBTAction {
 		t.Errorf("expected second block type 'actions', got %q", actions.Type)
 	}
-	if len(actions.Elements) != 3 {
-		t.Fatalf("expected 3 elements, got %d", len(actions.Elements))
+	if len(actions.Elements.ElementSet) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(actions.Elements.ElementSet))
 	}
 
 	// Verify each button's action_id, style, and value.
 	expectedButtons := []struct {
 		actionID string
-		style    string
+		style    goslack.Style
 		value    string
 	}{
-		{ActionIDQuestionResolved, ButtonStylePrimary, questionID},
+		{ActionIDQuestionResolved, goslack.StylePrimary, questionID},
 		{ActionIDQuestionContinue, "", questionID},
-		{ActionIDQuestionEscalate, ButtonStyleDanger, questionID},
+		{ActionIDQuestionEscalate, goslack.StyleDanger, questionID},
 	}
 
 	for i, expected := range expectedButtons {
-		btn := actions.Elements[i]
-		if btn.Type != "button" {
-			t.Errorf("element[%d]: expected type 'button', got %q", i, btn.Type)
+		btn, ok := actions.Elements.ElementSet[i].(*goslack.ButtonBlockElement)
+		if !ok {
+			t.Errorf("element[%d]: expected *ButtonBlockElement, got %T", i, actions.Elements.ElementSet[i])
+			continue
 		}
 		if btn.ActionID != expected.actionID {
 			t.Errorf("element[%d]: expected action_id %q, got %q", i, expected.actionID, btn.ActionID)
@@ -76,15 +85,19 @@ func TestBuildQuestionResponseBlocksEmptyResponse(t *testing.T) {
 	if len(blocks) != 2 {
 		t.Fatalf("expected 2 blocks, got %d", len(blocks))
 	}
-	if blocks[0].Text.Text != "" {
-		t.Errorf("expected empty text, got %q", blocks[0].Text.Text)
+	section, ok := blocks[0].(*goslack.SectionBlock)
+	if !ok {
+		t.Fatalf("expected first block to be *SectionBlock, got %T", blocks[0])
+	}
+	if section.Text.Text != "" {
+		t.Errorf("expected empty text, got %q", section.Text.Text)
 	}
 }
 
-func TestMarshalBlocks(t *testing.T) {
+func TestBuildQuestionResponseBlocksJSON(t *testing.T) {
 	blocks := BuildQuestionResponseBlocks("test response", "q-456")
 
-	data, err := MarshalBlocks(blocks)
+	data, err := json.Marshal(blocks)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/backend/pkg/slack/events.go
+++ b/backend/pkg/slack/events.go
@@ -1,70 +1,5 @@
 package slack
 
-// SlackEvent represents the top-level envelope for all Slack Events API payloads.
-type SlackEvent struct {
-	Token     string `json:"token"`
-	Type      string `json:"type"`
-	Challenge string `json:"challenge,omitempty"`
-
-	// Fields present when Type == "event_callback"
-	TeamID    string         `json:"team_id,omitempty"`
-	EventID   string         `json:"event_id,omitempty"`
-	EventTime int64          `json:"event_time,omitempty"`
-	Event     EventCallback  `json:"event,omitempty"`
-	Actions   []ActionDetail `json:"actions,omitempty"`
-
-	// Fields present for message_action (shortcut) payloads
-	CallbackID string  `json:"callback_id,omitempty"`
-	TriggerID  string  `json:"trigger_id,omitempty"`
-	User       IDField `json:"user,omitempty"`
-	Channel    IDField `json:"channel,omitempty"`
-	MessageTS  string  `json:"message_ts,omitempty"`
-	Message    Message `json:"message,omitempty"`
-}
-
-// EventCallback represents the inner event object within an event_callback envelope.
-type EventCallback struct {
-	Type string `json:"type"`
-
-	// Fields for reaction_added events
-	User     string       `json:"user,omitempty"`
-	Reaction string       `json:"reaction,omitempty"`
-	Item     ReactionItem `json:"item,omitempty"`
-	EventTS  string       `json:"event_ts,omitempty"`
-}
-
-// ReactionItem represents the item a reaction was added to.
-type ReactionItem struct {
-	Type    string `json:"type"`
-	Channel string `json:"channel"`
-	TS      string `json:"ts"`
-}
-
-// ActionDetail represents a single action in an interactive message payload.
-type ActionDetail struct {
-	ActionID string `json:"action_id"`
-	Type     string `json:"type"`
-	Value    string `json:"value,omitempty"`
-}
-
-// IDField is a helper for Slack objects that have an "id" field.
-type IDField struct {
-	ID string `json:"id"`
-}
-
-// Message represents a Slack message within an action payload.
-type Message struct {
-	Text     string `json:"text"`
-	TS       string `json:"ts"`
-	ThreadTS string `json:"thread_ts,omitempty"`
-	User     string `json:"user,omitempty"`
-}
-
-// URLVerificationResponse is the response for url_verification challenges.
-type URLVerificationResponse struct {
-	Challenge string `json:"challenge"`
-}
-
 // ThreadMessage represents a single message in a thread, used when bundling
 // thread history into SQS messages.
 type ThreadMessage struct {
@@ -73,10 +8,26 @@ type ThreadMessage struct {
 	TS   string `json:"ts"`
 }
 
-// Event type constants.
-const (
-	EventTypeURLVerification = "url_verification"
-	EventTypeEventCallback   = "event_callback"
-	EventTypeReactionAdded   = "reaction_added"
-	EventTypeMessageAction   = "message_action"
-)
+// MessageActionPayload represents a Slack message_action (shortcut) payload.
+// This type is needed because the slack-go library does not provide a dedicated
+// type for message_action payloads in the slackevents package.
+type MessageActionPayload struct {
+	Type       string `json:"type"`
+	CallbackID string `json:"callback_id"`
+	TriggerID  string `json:"trigger_id"`
+	User       struct {
+		ID string `json:"id"`
+	} `json:"user"`
+	Channel struct {
+		ID string `json:"id"`
+	} `json:"channel"`
+	Message struct {
+		Text     string `json:"text"`
+		TS       string `json:"ts"`
+		ThreadTS string `json:"thread_ts"`
+	} `json:"message"`
+}
+
+// Event type constant for message_action, which is not provided by the
+// slack-go slackevents package.
+const EventTypeMessageAction = "message_action"


### PR DESCRIPTION
## Summary
- `pkg/slack/blocks.go`: カスタム `Block`, `TextObj`, `Element` 型を `slack-go` の Block Kit API (`slack.NewSectionBlock`, `slack.NewButtonBlockElement` 等) に置き換え
- `pkg/slack/events.go`: カスタムイベント型を削除し、`slackevents.ParseEvent` / `slackevents.ReactionAddedEvent` 等に移行。`ThreadMessage` と `MessageActionPayload` のみ残存
- `api/rest/event_handler.go`: `slackevents` パッケージを使用したイベント解析に書き換え
- `api/rest/interaction_handler.go`: `slack.InteractionCallback` を使用したインタラクション解析に書き換え
- テスト更新済み

## Test plan
- [x] `go build ./...` が正常にパスすること
- [x] `go test ./...` が全テストパスすること
- [ ] Slack Events API (url_verification, reaction_added) が正常に動作すること
- [ ] Slack Interaction callbacks が正常に動作すること

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)