### PR TITLE
fix(security): address review findings for PR #147

### DIFF
--- a/backend/api/middleware/ratelimit.go
+++ b/backend/api/middleware/ratelimit.go
@@ -57,6 +57,8 @@ func (rl *RateLimiter) cleanup() {
 	}
 }
 
+const maxRateLimitEntries = 100000
+
 func (rl *RateLimiter) Allow(key string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
@@ -64,11 +66,17 @@ func (rl *RateLimiter) Allow(key string) bool {
 	now := time.Now()
 	entry, exists := rl.entries[key]
 	if !exists || now.After(entry.resetAt) {
+		if len(rl.entries) >= maxRateLimitEntries {
+			return false
+		}
 		rl.entries[key] = &rateLimitEntry{count: 1, resetAt: now.Add(rl.window)}
 		return true
 	}
+	if entry.count >= rl.limit {
+		return false
+	}
 	entry.count++
-	return entry.count <= rl.limit
+	return true
 }
 
 // authRateLimitedPaths are the paths that should be rate limited.

--- a/backend/api/middleware/slack.go
+++ b/backend/api/middleware/slack.go
@@ -26,7 +26,7 @@ func SlackVerification(verifier *pkgslack.Verifier) gin.HandlerFunc {
 			slog.String("method", c.Request.Method),
 			slog.String("path", c.Request.URL.Path),
 			slog.String("content_type", c.GetHeader("Content-Type")),
-			slog.String("body", string(body)),
+			slog.Int("body_length", len(body)),
 		)
 
 		c.Request.Body = io.NopCloser(bytes.NewReader(body))

--- a/backend/api/rest/handlers/github_handler.go
+++ b/backend/api/rest/handlers/github_handler.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/Asheze1127/progress-checker/backend/api/openapi"
@@ -18,12 +20,23 @@ func NewGitHubHandler(service *githubsvc.GitHubService) *GitHubHandler {
 	return &GitHubHandler{service: service}
 }
 
+// isAuthError returns true if the error is an authorization failure.
+// NOTE: Ideally these should map to 401/403 responses, but the OpenAPI spec
+// does not define those response types for GitHub endpoints yet. Using 400
+// until the spec is updated and the server code is regenerated.
+func isAuthError(err error) bool {
+	return errors.Is(err, githubsvc.ErrGitHubNotAuthorized) || errors.Is(err, githubsvc.ErrGitHubNotAuthorizedForTeam)
+}
+
 // ListRepositories handles GET /api/v1/teams/{teamId}/github-repos.
 func (h *GitHubHandler) ListRepositories(ctx context.Context, request openapi.ListRepositoriesRequestObject) (openapi.ListRepositoriesResponseObject, error) {
 	repos, err := h.service.ListRepositories(ctx, request.TeamId)
 	if err != nil {
+		if isAuthError(err) {
+			return openapi.ListRepositories400JSONResponse{Error: "not authorized for this team"}, nil
+		}
 		slog.Error("failed to list repositories", slog.String("error", err.Error()))
-		return openapi.ListRepositories400JSONResponse{Error: "failed to list repositories"}, nil
+		return nil, fmt.Errorf("failed to list repositories: %w", err)
 	}
 
 	items := make([]openapi.RepoItem, 0, len(repos))
@@ -41,6 +54,9 @@ func (h *GitHubHandler) ListRepositories(ctx context.Context, request openapi.Li
 // RegisterRepository handles POST /api/v1/teams/{teamId}/github-repos.
 func (h *GitHubHandler) RegisterRepository(ctx context.Context, request openapi.RegisterRepositoryRequestObject) (openapi.RegisterRepositoryResponseObject, error) {
 	if err := h.service.RegisterRepository(ctx, request.TeamId, request.Body.GithubRepoUrl, request.Body.PersonalAccessToken); err != nil {
+		if isAuthError(err) {
+			return openapi.RegisterRepository400JSONResponse{Error: "not authorized for this team"}, nil
+		}
 		slog.Error("failed to register repository", slog.String("error", err.Error()))
 		return openapi.RegisterRepository400JSONResponse{Error: "failed to register repository"}, nil
 	}
@@ -51,6 +67,9 @@ func (h *GitHubHandler) RegisterRepository(ctx context.Context, request openapi.
 // RemoveRepository handles DELETE /api/v1/teams/{teamId}/github-repos/{repoId}.
 func (h *GitHubHandler) RemoveRepository(ctx context.Context, request openapi.RemoveRepositoryRequestObject) (openapi.RemoveRepositoryResponseObject, error) {
 	if err := h.service.RemoveRepository(ctx, request.TeamId, request.RepoId); err != nil {
+		if isAuthError(err) {
+			return openapi.RemoveRepository400JSONResponse{Error: "not authorized for this team"}, nil
+		}
 		slog.Error("failed to remove repository", slog.String("error", err.Error()))
 		return openapi.RemoveRepository400JSONResponse{Error: "failed to remove repository"}, nil
 	}
@@ -61,6 +80,9 @@ func (h *GitHubHandler) RemoveRepository(ctx context.Context, request openapi.Re
 // UpdateToken handles PUT /api/v1/teams/{teamId}/github-repos/{repoId}/token.
 func (h *GitHubHandler) UpdateToken(ctx context.Context, request openapi.UpdateTokenRequestObject) (openapi.UpdateTokenResponseObject, error) {
 	if err := h.service.UpdateToken(ctx, request.TeamId, request.RepoId, request.Body.PersonalAccessToken); err != nil {
+		if isAuthError(err) {
+			return openapi.UpdateToken400JSONResponse{Error: "not authorized for this team"}, nil
+		}
 		slog.Error("failed to update token", slog.String("error", err.Error()))
 		return openapi.UpdateToken400JSONResponse{Error: "failed to update token"}, nil
 	}

--- a/backend/api/rest/handlers/participant_handler.go
+++ b/backend/api/rest/handlers/participant_handler.go
@@ -62,8 +62,11 @@ func (h *ParticipantHandler) RegisterParticipant(ctx context.Context, request op
 		if errors.Is(err, usecase.ErrNotAuthorized) || errors.Is(err, usecase.ErrNotAuthorizedForTeam) {
 			return openapi.RegisterParticipant403JSONResponse{Error: "not authorized"}, nil
 		}
-		if errors.Is(err, usecase.ErrTeamNotFound) || errors.Is(err, usecase.ErrUserAlreadyExists) {
-			return openapi.RegisterParticipant400JSONResponse{Error: err.Error()}, nil
+		if errors.Is(err, usecase.ErrTeamNotFound) {
+			return openapi.RegisterParticipant400JSONResponse{Error: "team not found"}, nil
+		}
+		if errors.Is(err, usecase.ErrUserAlreadyExists) {
+			return openapi.RegisterParticipant400JSONResponse{Error: "participant already registered"}, nil
 		}
 		return nil, err
 	}

--- a/backend/api/webhook/command_handler.go
+++ b/backend/api/webhook/command_handler.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -37,7 +38,7 @@ func (h *CommandHandler) HandleCommand(c *gin.Context) {
 	case "/create-mentor":
 		h.handleCreateMentor(c, callerID, text)
 	default:
-		c.JSON(http.StatusOK, gin.H{"text": fmt.Sprintf("Unknown command: %s", command)})
+		c.JSON(http.StatusOK, gin.H{"text": "Unsupported command"})
 	}
 }
 
@@ -56,9 +57,9 @@ func (h *CommandHandler) handleCreateMentor(c *gin.Context, callerSlackID, text 
 		slog.Error("failed to create mentor", slog.String("error", err.Error()), slog.String("caller", callerSlackID))
 		// Return a safe message; full error is logged server-side
 		safeMsg := "Failed to create mentor. Please check the team name and user, then try again."
-		if strings.Contains(err.Error(), "not a registered staff") {
+		if errors.Is(err, usecase.ErrNotStaff) {
 			safeMsg = "You are not authorized to use this command."
-		} else if strings.Contains(err.Error(), "not found") {
+		} else if errors.Is(err, usecase.ErrTeamNotFound) {
 			safeMsg = fmt.Sprintf("Team %q not found. Please check the team name.", teamName)
 		}
 		c.JSON(http.StatusOK, gin.H{
@@ -68,13 +69,13 @@ func (h *CommandHandler) handleCreateMentor(c *gin.Context, callerSlackID, text 
 		return
 	}
 
-	slog.Info("mentor created", slog.String("mentor_id", string(result.User.ID)), slog.String("staff_caller", callerSlackID), slog.String("team", teamName))
+	slog.Info("mentor created", slog.String("mentor_id", string(result.User.ID)), slog.String("caller", callerSlackID), slog.String("team", teamName))
 
 	c.JSON(http.StatusOK, gin.H{
 		"response_type": "ephemeral",
 		"text": fmt.Sprintf(
 			"Mentor created successfully!\nName: %s\nTeam: %s\nSetup URL: %s\n\nPlease share this URL with the mentor to set their password.",
-			result.User.Name, teamName, result.SetupURL,
+			sanitizeSlackText(result.User.Name), teamName, result.SetupURL,
 		),
 	})
 }
@@ -101,5 +102,15 @@ func parseCreateMentorArgs(text string) (slackUserID, teamName string, err error
 		return "", "", fmt.Errorf("team name is too long (max %d characters)", maxTeamNameLength)
 	}
 
+	// Sanitize Slack formatting metacharacters to prevent injection
+	remaining = sanitizeSlackText(remaining)
+
 	return slackUserID, remaining, nil
+}
+
+// sanitizeSlackText strips Slack mrkdwn metacharacters that could be abused
+// for link injection, channel mentions, or user mentions.
+func sanitizeSlackText(s string) string {
+	r := strings.NewReplacer("<", "", ">", "", "&", "&amp;")
+	return r.Replace(s)
 }

--- a/backend/application/service/github/service.go
+++ b/backend/application/service/github/service.go
@@ -2,24 +2,48 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/Asheze1127/progress-checker/backend/application/appcontext"
 	githubissuecreator "github.com/Asheze1127/progress-checker/backend/application/service/github_issue_creator"
 	"github.com/Asheze1127/progress-checker/backend/application/service/token_encryptor"
 	"github.com/Asheze1127/progress-checker/backend/entities"
+)
+
+var (
+	ErrGitHubNotAuthorized        = errors.New("not authorized")
+	ErrGitHubNotAuthorizedForTeam = errors.New("not authorized for this team")
 )
 
 type GitHubService struct {
 	repo       entities.GitHubRepoRepository
 	encryptor  tokenencryptor.TokenEncryptor
 	ghClient   githubissuecreator.GitHubIssueCreator
+	mentorRepo entities.MentorRepository
 	idProvider func() string
 }
 
-func NewGitHubService(repo entities.GitHubRepoRepository, encryptor tokenencryptor.TokenEncryptor, ghClient githubissuecreator.GitHubIssueCreator, idProvider func() string) *GitHubService {
-	return &GitHubService{repo: repo, encryptor: encryptor, ghClient: ghClient, idProvider: idProvider}
+func NewGitHubService(repo entities.GitHubRepoRepository, encryptor tokenencryptor.TokenEncryptor, ghClient githubissuecreator.GitHubIssueCreator, mentorRepo entities.MentorRepository, idProvider func() string) *GitHubService {
+	return &GitHubService{repo: repo, encryptor: encryptor, ghClient: ghClient, mentorRepo: mentorRepo, idProvider: idProvider}
+}
+
+// verifyTeamAccess checks that the authenticated mentor from context is a member of the given team.
+func (s *GitHubService) verifyTeamAccess(ctx context.Context, teamID string) error {
+	user := appcontext.UserFromContext(ctx)
+	if user == nil {
+		return ErrGitHubNotAuthorized
+	}
+	mentor, err := s.mentorRepo.GetByUserID(ctx, user.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get mentor: %w", err)
+	}
+	if !mentor.BelongsToTeam(entities.TeamID(teamID)) {
+		return ErrGitHubNotAuthorizedForTeam
+	}
+	return nil
 }
 
 func (s *GitHubService) RegisterRepository(ctx context.Context, teamID string, repoURL string, pat string) error {
@@ -28,6 +52,9 @@ func (s *GitHubService) RegisterRepository(ctx context.Context, teamID string, r
 	}
 	if strings.TrimSpace(pat) == "" {
 		return fmt.Errorf("personal_access_token is required")
+	}
+	if err := s.verifyTeamAccess(ctx, teamID); err != nil {
+		return err
 	}
 	owner, repoName, err := entities.ParseGitHubRepoURL(repoURL)
 	if err != nil {
@@ -49,6 +76,9 @@ func (s *GitHubService) ListRepositories(ctx context.Context, teamID string) ([]
 	if strings.TrimSpace(teamID) == "" {
 		return nil, fmt.Errorf("team_id is required")
 	}
+	if err := s.verifyTeamAccess(ctx, teamID); err != nil {
+		return nil, err
+	}
 	repos, err := s.repo.FindByTeamID(ctx, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("find github repos: %w", err)
@@ -62,6 +92,9 @@ func (s *GitHubService) RemoveRepository(ctx context.Context, teamID string, rep
 	}
 	if strings.TrimSpace(repoID) == "" {
 		return fmt.Errorf("repo_id is required")
+	}
+	if err := s.verifyTeamAccess(ctx, teamID); err != nil {
+		return err
 	}
 	existing, err := s.repo.FindByID(ctx, repoID)
 	if err != nil {
@@ -85,6 +118,9 @@ func (s *GitHubService) UpdateToken(ctx context.Context, teamID string, repoID s
 	}
 	if strings.TrimSpace(newPAT) == "" {
 		return fmt.Errorf("personal_access_token is required")
+	}
+	if err := s.verifyTeamAccess(ctx, teamID); err != nil {
+		return err
 	}
 	existing, err := s.repo.FindByID(ctx, repoID)
 	if err != nil {

--- a/backend/application/usecase/create_mentor.go
+++ b/backend/application/usecase/create_mentor.go
@@ -2,13 +2,21 @@ package usecase
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
+	db "github.com/Asheze1127/progress-checker/backend/database/postgres/generated"
 	"github.com/Asheze1127/progress-checker/backend/entities"
 	slackinfra "github.com/Asheze1127/progress-checker/backend/infrastructure/slack"
+	"github.com/google/uuid"
+)
+
+var (
+	ErrNotStaff = errors.New("caller is not a registered staff member")
 )
 
 const setupTokenExpiry = 24 * time.Hour
@@ -27,9 +35,8 @@ type CreateMentorUseCase struct {
 	staffRepo       entities.StaffRepository
 	userRepo        entities.UserRepository
 	teamRepo        entities.TeamRepository
-	setupTokenRepo  entities.SetupTokenRepository
-	mentorRepo      entities.MentorRepository
 	slackClient     SlackUserInfoFetcher
+	database        *sql.DB
 	frontendBaseURL string
 	now             func() time.Time
 }
@@ -38,18 +45,16 @@ func NewCreateMentorUseCase(
 	staffRepo entities.StaffRepository,
 	userRepo entities.UserRepository,
 	teamRepo entities.TeamRepository,
-	setupTokenRepo entities.SetupTokenRepository,
-	mentorRepo entities.MentorRepository,
 	slackClient SlackUserInfoFetcher,
+	database *sql.DB,
 	frontendBaseURL string,
 ) *CreateMentorUseCase {
 	return &CreateMentorUseCase{
 		staffRepo:       staffRepo,
 		userRepo:        userRepo,
 		teamRepo:        teamRepo,
-		setupTokenRepo:  setupTokenRepo,
-		mentorRepo:      mentorRepo,
 		slackClient:     slackClient,
+		database:        database,
 		frontendBaseURL: frontendBaseURL,
 		now:             time.Now,
 	}
@@ -83,13 +88,16 @@ func (uc *CreateMentorUseCase) Execute(ctx context.Context, callerSlackID, mento
 		return nil, fmt.Errorf("caller has no email address in Slack profile")
 	}
 	if _, err := uc.staffRepo.FindByEmail(ctx, callerSlackUser.Email); err != nil {
-		return nil, fmt.Errorf("caller is not a registered staff member")
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotStaff
+		}
+		return nil, fmt.Errorf("failed to verify staff status: %w", err)
 	}
 
 	// Find the team by name
 	team, err := uc.teamRepo.GetByName(ctx, teamName)
 	if err != nil {
-		return nil, fmt.Errorf("team %q not found", teamName)
+		return nil, ErrTeamNotFound
 	}
 
 	// Fetch mentor's Slack profile
@@ -99,8 +107,12 @@ func (uc *CreateMentorUseCase) Execute(ctx context.Context, callerSlackID, mento
 	}
 
 	// Check if user already exists
-	if existing, err := uc.userRepo.GetBySlackUserID(ctx, entities.SlackUserID(mentorSlackID)); err == nil && existing != nil {
+	_, existErr := uc.userRepo.GetBySlackUserID(ctx, entities.SlackUserID(mentorSlackID))
+	if existErr == nil {
 		return nil, fmt.Errorf("user with Slack ID %s already exists", mentorSlackID)
+	}
+	if !errors.Is(existErr, sql.ErrNoRows) {
+		return nil, fmt.Errorf("failed to check existing user: %w", existErr)
 	}
 
 	name := slackUser.RealName
@@ -113,39 +125,72 @@ func (uc *CreateMentorUseCase) Execute(ctx context.Context, callerSlackID, mento
 		return nil, fmt.Errorf("slack user has no email address configured")
 	}
 
-	// Create the user with mentor role
-	user := &entities.User{
-		SlackUserID: entities.SlackUserID(mentorSlackID),
-		Name:        name,
-		Email:       email,
-		Role:        entities.UserRoleMentor,
-	}
-
-	createdUser, err := uc.userRepo.Create(ctx, user, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create mentor user: %w", err)
-	}
-
-	// Create mentor record + team assignment
-	if err := uc.mentorRepo.Create(ctx, createdUser.ID); err != nil {
-		return nil, fmt.Errorf("failed to create mentor record: %w", err)
-	}
-
-	if err := uc.mentorRepo.AssignTeam(ctx, createdUser.ID, team.ID); err != nil {
-		return nil, fmt.Errorf("failed to assign mentor to team: %w", err)
-	}
-
-	// Generate setup token
+	// Generate setup token before the transaction
 	rawToken, err := generateSetupToken()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate setup token: %w", err)
 	}
-
 	tokenHash := hashToken(rawToken)
 	expiresAt := uc.now().Add(setupTokenExpiry)
 
-	if _, err := uc.setupTokenRepo.Create(ctx, createdUser.ID, tokenHash, expiresAt); err != nil {
+	teamID, err := uuid.Parse(string(team.ID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse team ID: %w", err)
+	}
+
+	// Execute all DB writes in a single transaction
+	tx, err := uc.database.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	qtx := db.New(tx)
+
+	// Create user
+	userRow, err := qtx.CreateUser(ctx, db.CreateUserParams{
+		SlackUserID:  mentorSlackID,
+		Name:         name,
+		Email:        email,
+		Role:         string(entities.UserRoleMentor),
+		PasswordHash: "",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mentor user: %w", err)
+	}
+
+	// Create mentor record
+	if err := qtx.CreateMentor(ctx, userRow.ID); err != nil {
+		return nil, fmt.Errorf("failed to create mentor record: %w", err)
+	}
+
+	// Assign team
+	if err := qtx.CreateMentorTeamAssignment(ctx, db.CreateMentorTeamAssignmentParams{
+		MentorUserID: userRow.ID,
+		TeamID:       teamID,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to assign mentor to team: %w", err)
+	}
+
+	// Create setup token
+	if _, err := qtx.CreateSetupToken(ctx, db.CreateSetupTokenParams{
+		UserID:    userRow.ID,
+		TokenHash: tokenHash,
+		ExpiresAt: expiresAt,
+	}); err != nil {
 		return nil, fmt.Errorf("failed to store setup token: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	createdUser := &entities.User{
+		ID:          entities.UserID(userRow.ID.String()),
+		SlackUserID: entities.SlackUserID(userRow.SlackUserID),
+		Name:        userRow.Name,
+		Email:       userRow.Email,
+		Role:        entities.UserRole(userRow.Role),
 	}
 
 	setupURL := fmt.Sprintf("%s/setup?token=%s", strings.TrimRight(uc.frontendBaseURL, "/"), rawToken)

--- a/backend/application/usecase/handle_new_question.go
+++ b/backend/application/usecase/handle_new_question.go
@@ -44,6 +44,9 @@ func (uc *HandleNewQuestionUseCase) Execute(ctx context.Context, input HandleNew
 	}()
 
 	questionID := uuid.New().String()
+	// TODO: SlackThreadTS should be set after the Slack message is posted by the queue consumer,
+	// not as a UUID placeholder. This requires making SlackThreadTS optional in the entity
+	// and updating it after the consumer posts the message and receives the actual thread_ts.
 	threadTS := uuid.New().String()
 
 	question := &entities.Question{

--- a/backend/application/usecase/register_participant.go
+++ b/backend/application/usecase/register_participant.go
@@ -2,14 +2,17 @@ package usecase
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 
 	"github.com/Asheze1127/progress-checker/backend/application/appcontext"
+	db "github.com/Asheze1127/progress-checker/backend/database/postgres/generated"
 	"github.com/Asheze1127/progress-checker/backend/entities"
 	slackinfra "github.com/Asheze1127/progress-checker/backend/infrastructure/slack"
+	"github.com/google/uuid"
 )
 
 var (
@@ -21,8 +24,8 @@ type RegisterParticipantUseCase struct {
 	userRepo        entities.UserRepository
 	teamRepo        entities.TeamRepository
 	mentorRepo      entities.MentorRepository
-	participantRepo entities.ParticipantRepository
 	slackClient     SlackUserInfoFetcher
+	database        *sql.DB
 }
 
 // SlackUserInfoFetcher is already defined in create_mentor.go but we need it here too.
@@ -32,15 +35,15 @@ func NewRegisterParticipantUseCase(
 	userRepo entities.UserRepository,
 	teamRepo entities.TeamRepository,
 	mentorRepo entities.MentorRepository,
-	participantRepo entities.ParticipantRepository,
 	slackClient SlackUserInfoFetcher,
+	database *sql.DB,
 ) *RegisterParticipantUseCase {
 	return &RegisterParticipantUseCase{
-		userRepo:        userRepo,
-		teamRepo:        teamRepo,
-		mentorRepo:      mentorRepo,
-		participantRepo: participantRepo,
-		slackClient:     slackClient,
+		userRepo:    userRepo,
+		teamRepo:    teamRepo,
+		mentorRepo:  mentorRepo,
+		slackClient: slackClient,
+		database:    database,
 	}
 }
 
@@ -103,21 +106,48 @@ func (uc *RegisterParticipantUseCase) Execute(ctx context.Context, slackUserID, 
 		return nil, fmt.Errorf("slack user has no email address configured")
 	}
 
-	// Create participant user (no password needed)
-	user := &entities.User{
-		SlackUserID: entities.SlackUserID(slackUserID),
-		Name:        name,
-		Email:       email,
-		Role:        entities.UserRoleParticipant,
+	teamUUID, err := uuid.Parse(teamID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid team ID: %w", err)
 	}
 
-	createdUser, err := uc.userRepo.Create(ctx, user, "")
+	// Execute both DB writes in a single transaction
+	tx, err := uc.database.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	qtx := db.New(tx)
+
+	userRow, err := qtx.CreateUser(ctx, db.CreateUserParams{
+		SlackUserID:  slackUserID,
+		Name:         name,
+		Email:        email,
+		Role:         string(entities.UserRoleParticipant),
+		PasswordHash: "",
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create participant: %w", err)
 	}
 
-	if err := uc.participantRepo.Create(ctx, createdUser.ID, entities.TeamID(teamID)); err != nil {
+	if err := qtx.CreateParticipant(ctx, db.CreateParticipantParams{
+		UserID: userRow.ID,
+		TeamID: teamUUID,
+	}); err != nil {
 		return nil, fmt.Errorf("failed to create participant record: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	createdUser := &entities.User{
+		ID:          entities.UserID(userRow.ID.String()),
+		SlackUserID: entities.SlackUserID(userRow.SlackUserID),
+		Name:        userRow.Name,
+		Email:       userRow.Email,
+		Role:        entities.UserRole(userRow.Role),
 	}
 
 	return createdUser, nil

--- a/backend/application/usecase/setup_password.go
+++ b/backend/application/usecase/setup_password.go
@@ -63,10 +63,10 @@ func (uc *SetupPasswordUseCase) Execute(ctx context.Context, rawToken, password 
 	if rawToken == "" {
 		return ErrSetupTokenInvalid
 	}
-	if len(password) < minPasswordLength {
+	if len([]rune(password)) < minPasswordLength {
 		return ErrPasswordTooShort
 	}
-	if len(password) > maxPasswordLength {
+	if len([]rune(password)) > maxPasswordLength {
 		return ErrPasswordTooLong
 	}
 	if !isPasswordComplex(password) {

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"os"
 
@@ -13,16 +14,14 @@ import (
 )
 
 type seedStaff struct {
-	Name     string
-	Email    string
-	Password string
+	Name  string
+	Email string
 }
 
 var staffMembers = []seedStaff{
 	{
-		Name:     "Tsubasa Ito",
-		Email:    "ito.tsubasa577@gmail.com",
-		Password: "ito.tsubasa577@gmail.com",
+		Name:  "Tsubasa Ito",
+		Email: "ito.tsubasa577@gmail.com",
 	},
 }
 
@@ -42,10 +41,15 @@ func main() {
 		log.Fatalf("failed to connect to database: %v", err)
 	}
 
+	seedPassword := os.Getenv("SEED_STAFF_PASSWORD")
+	if seedPassword == "" {
+		log.Fatal("SEED_STAFF_PASSWORD environment variable is required")
+	}
+
 	hasher := util.NewPasswordHasher()
 
 	for _, s := range staffMembers {
-		hash, err := hasher.Hash(s.Password)
+		hash, err := hasher.Hash(seedPassword)
 		if err != nil {
 			log.Fatalf("failed to hash password for %s: %v", s.Email, err)
 		}
@@ -75,17 +79,16 @@ func loadDBConfig() (string, error) {
 	name := envOrDefault("DATABASE_NAME", "progress_checker")
 	user := envOrDefault("DATABASE_USER", "postgres")
 	pass := envOrDefault("DATABASE_PASS", "postgres")
-	sslMode := envOrDefault("DATABASE_SSL_MODE", "disable")
+	sslMode := envOrDefault("DATABASE_SSL_MODE", "require")
 
-	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		url.PathEscape(user),
-		url.PathEscape(pass),
-		url.PathEscape(host),
-		url.PathEscape(port),
-		url.PathEscape(name),
-		url.QueryEscape(sslMode),
-	)
-	return dsn, nil
+	u := &url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, pass),
+		Host:     net.JoinHostPort(host, port),
+		Path:     name,
+		RawQuery: url.Values{"sslmode": {sslMode}}.Encode(),
+	}
+	return u.String(), nil
 }
 
 func envOrDefault(key, defaultValue string) string {

--- a/backend/cmd/serve/di.go
+++ b/backend/cmd/serve/di.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -39,15 +40,14 @@ func wireRouter(cfg *util.Config) (http.Handler, error) {
 
 	// --- Infrastructure ---
 	do.Provide(injector, func(i do.Injector) (*sql.DB, error) {
-		dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-			url.PathEscape(cfg.DatabaseUser),
-			url.PathEscape(cfg.DatabasePass),
-			url.PathEscape(cfg.DatabaseHost),
-			url.PathEscape(cfg.DatabasePort),
-			url.PathEscape(cfg.DatabaseName),
-			url.QueryEscape(cfg.DatabaseSSLMode),
-		)
-		db, err := sql.Open("postgres", dsn)
+		u := &url.URL{
+			Scheme:   "postgres",
+			User:     url.UserPassword(cfg.DatabaseUser, cfg.DatabasePass),
+			Host:     net.JoinHostPort(cfg.DatabaseHost, cfg.DatabasePort),
+			Path:     cfg.DatabaseName,
+			RawQuery: url.Values{"sslmode": {cfg.DatabaseSSLMode}}.Encode(),
+		}
+		db, err := sql.Open("postgres", u.String())
 		if err != nil {
 			return nil, fmt.Errorf("failed to open database: %w", err)
 		}
@@ -162,14 +162,15 @@ func wireRouter(cfg *util.Config) (http.Handler, error) {
 	})
 
 	do.Provide(injector, func(i do.Injector) (*pkgslack.Verifier, error) {
-		return pkgslack.NewVerifier(cfg.SlackSigningSecret), nil
+		return pkgslack.NewVerifier(cfg.SlackSigningSecret)
 	})
 
 	do.Provide(injector, func(i do.Injector) (*githubsvc.GitHubService, error) {
 		ghRepoRepo := do.MustInvoke[*postgres.GitHubRepoRepository](i)
 		encryptor := do.MustInvoke[*encryption.AESEncryptor](i)
 		ghClient := do.MustInvoke[*githubclient.Client](i) // implements githubissuecreator.GitHubIssueCreator
-		return githubsvc.NewGitHubService(ghRepoRepo, encryptor, ghClient, func() string {
+		mentorRepo := do.MustInvoke[*postgres.MentorRepository](i)
+		return githubsvc.NewGitHubService(ghRepoRepo, encryptor, ghClient, mentorRepo, func() string {
 			return uuid.New().String()
 		}), nil
 	})
@@ -240,19 +241,18 @@ func wireRouter(cfg *util.Config) (http.Handler, error) {
 		staffRepo := do.MustInvoke[*postgres.StaffRepository](i)
 		userRepo := do.MustInvoke[*postgres.UserRepository](i)
 		teamRepo := do.MustInvoke[*postgres.TeamRepository](i)
-		setupTokenRepo := do.MustInvoke[*postgres.SetupTokenRepository](i)
-		mentorRepo := do.MustInvoke[*postgres.MentorRepository](i)
 		slackClient := do.MustInvoke[*slackinfra.Client](i)
-		return usecase.NewCreateMentorUseCase(staffRepo, userRepo, teamRepo, setupTokenRepo, mentorRepo, slackClient, cfg.FrontendBaseURL), nil
+		database := do.MustInvoke[*sql.DB](i)
+		return usecase.NewCreateMentorUseCase(staffRepo, userRepo, teamRepo, slackClient, database, cfg.FrontendBaseURL), nil
 	})
 
 	do.Provide(injector, func(i do.Injector) (*usecase.RegisterParticipantUseCase, error) {
 		userRepo := do.MustInvoke[*postgres.UserRepository](i)
 		teamRepo := do.MustInvoke[*postgres.TeamRepository](i)
 		mentorRepo := do.MustInvoke[*postgres.MentorRepository](i)
-		participantRepo := do.MustInvoke[*postgres.ParticipantRepository](i)
 		slackClient := do.MustInvoke[*slackinfra.Client](i)
-		return usecase.NewRegisterParticipantUseCase(userRepo, teamRepo, mentorRepo, participantRepo, slackClient), nil
+		database := do.MustInvoke[*sql.DB](i)
+		return usecase.NewRegisterParticipantUseCase(userRepo, teamRepo, mentorRepo, slackClient, database), nil
 	})
 
 	do.Provide(injector, func(i do.Injector) (*usecase.SetupPasswordUseCase, error) {

--- a/backend/infrastructure/sqs/client.go
+++ b/backend/infrastructure/sqs/client.go
@@ -3,6 +3,7 @@ package sqs
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
@@ -15,25 +16,25 @@ var _ messagequeue.MessageQueue = (*Client)(nil)
 
 // Client implements the port.MessageQueue interface using AWS SQS.
 type Client struct {
-	api *sqs.Client
+	api      *sqs.Client
+	mu       sync.RWMutex
+	urlCache map[string]string
 }
 
 // NewClient creates a new SQS Client with the given AWS SQS client.
 func NewClient(api *sqs.Client) *Client {
-	return &Client{api: api}
+	return &Client{api: api, urlCache: make(map[string]string)}
 }
 
 // Send sends a message to the specified SQS queue by name.
 func (c *Client) Send(ctx context.Context, queueName string, message []byte) error {
-	urlOutput, err := c.api.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
-		QueueName: aws.String(queueName),
-	})
+	queueURL, err := c.resolveQueueURL(ctx, queueName)
 	if err != nil {
-		return fmt.Errorf("failed to get queue URL for %q: %w", queueName, err)
+		return err
 	}
 
 	_, err = c.api.SendMessage(ctx, &sqs.SendMessageInput{
-		QueueUrl:    urlOutput.QueueUrl,
+		QueueUrl:    aws.String(queueURL),
 		MessageBody: aws.String(string(message)),
 	})
 	if err != nil {
@@ -41,4 +42,34 @@ func (c *Client) Send(ctx context.Context, queueName string, message []byte) err
 	}
 
 	return nil
+}
+
+func (c *Client) resolveQueueURL(ctx context.Context, queueName string) (string, error) {
+	c.mu.RLock()
+	if url, ok := c.urlCache[queueName]; ok {
+		c.mu.RUnlock()
+		return url, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if url, ok := c.urlCache[queueName]; ok {
+		return url, nil
+	}
+
+	urlOutput, err := c.api.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
+		QueueName: aws.String(queueName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get queue URL for %q: %w", queueName, err)
+	}
+	if urlOutput.QueueUrl == nil {
+		return "", fmt.Errorf("AWS returned nil queue URL for %q", queueName)
+	}
+
+	c.urlCache[queueName] = *urlOutput.QueueUrl
+	return *urlOutput.QueueUrl, nil
 }

--- a/backend/pkg/slack/verify.go
+++ b/backend/pkg/slack/verify.go
@@ -21,10 +21,14 @@ type Verifier struct {
 }
 
 // NewVerifier creates a new Verifier with the given Slack signing secret.
-func NewVerifier(signingSecret string) *Verifier {
+// Returns an error if the signing secret is empty.
+func NewVerifier(signingSecret string) (*Verifier, error) {
+	if len(signingSecret) == 0 {
+		return nil, errors.New("slack signing secret must not be empty")
+	}
 	return &Verifier{
 		signingSecret: signingSecret,
-	}
+	}, nil
 }
 
 // Verify checks that the request has a valid Slack signature using slack-go's SecretsVerifier.
@@ -35,7 +39,8 @@ func (v *Verifier) Verify(r *http.Request) ([]byte, error) {
 		return nil, ErrInvalidSignature
 	}
 
-	body, err := io.ReadAll(io.TeeReader(r.Body, &sv))
+	const maxSlackBodyBytes = 2 << 20 // 2 MB
+	body, err := io.ReadAll(io.TeeReader(io.LimitReader(r.Body, maxSlackBodyBytes), &sv))
 	if err != nil {
 		return nil, fmt.Errorf("reading request body: %w", err)
 	}

--- a/backend/pkg/slack/verify_test.go
+++ b/backend/pkg/slack/verify_test.go
@@ -84,7 +84,10 @@ func TestVerifier_Verify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			verifier := NewVerifier(signingSecret)
+			verifier, err := NewVerifier(signingSecret)
+			if err != nil {
+				t.Fatalf("failed to create verifier: %v", err)
+			}
 
 			req := httptest.NewRequest(http.MethodPost, "/webhook/slack", strings.NewReader(tt.body))
 			if tt.signature != "" {


### PR DESCRIPTION
## Summary
PR #147 のコードレビューで発見されたセキュリティ・品質問題を修正。

### Critical/High fixes:
- **ハードコードされたパスワードの除去**: seed スクリプトから平文パスワードを除去し、`SEED_STAFF_PASSWORD` 環境変数を必須化
- **DSN インジェクション防止**: `url.PathEscape` を `url.URL` 構造体に置き換え、認証情報の正しいエンコードを保証
- **トランザクション追加**: `create_mentor` と `register_participant` の DB 書き込みをトランザクションで保護し、部分的な状態を防止
- **認可チェック追加**: GitHub リポジトリエンドポイントにチーム所属確認を追加（任意のメンターが他チームのリポジトリを操作可能だった問題を修正）
- **Slack 署名検証の強化**: 空の署名シークレットの検証とリクエストボディサイズ制限 (2MB) を追加

### Medium fixes:
- レートリミッタの改善（エントリ数上限、拒否時のカウント非加算）
- Slack テキストのサニタイズ（mrkdwn インジェクション防止）
- エラーハンドリング: センチネルエラーの使用、内部エラーの非公開化
- パスワード長チェックのルーンカウント対応（マルチバイト安全）
- SQS キュー URL のキャッシュ化
- ログから PII（リクエストボディ）を除去

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests)
- [x] Security review: no critical/high issues remaining
- [x] Code review: no critical/high issues remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)